### PR TITLE
Jan/d 1974 popover for select field should display cancel as option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,46 @@ customFileHandler: () => {
 }
 ```
 
+### Initial File Value Handler
+
+As file can be represented as any string, even a URL, so we need a way to convert back that string into an actual file value, we can provide `initialFileValueHandler` for this case
+
+```dart
+initialFileValueHandler: () => {
+  'profile_photo': (dynamic defaultValue) async {
+    if(defaultValue is List) 
+    // fetch list of images logic here
+    return;
+    if(defaultValue is String){
+      final file = await fetchOurFileFromUrl(defaultValue);
+      return [SchemaFormFile(name: file.name, bytes: await file.readAsBytes(), value: defaultValue )]
+    }
+    
+  },
+  '*': null
+}
+
+Future<List<SchemaFormFile>?> _defaultInitialFileValueHandler(
+    dynamic defaultValue) async {
+  Future<SchemaFormFile?> schemaFileFromUrl(String url) async {
+    // file fetching logic here
+  }
+
+  if (defaultValue is List) {
+    final result =
+        await Future.wait(defaultValue.cast<String>().map(schemaFileFromUrl));
+    return result.whereType<SchemaFormFile>().toList();
+  }
+
+  if (defaultValue is String) {
+    final file = await schemaFileFromUrl(defaultValue);
+    if (file != null) return [file];
+  }
+
+  return null;
+}
+```
+
 ### Using Custom Validator
 
 ```dart

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+# platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,69 +1,16 @@
 PODS:
-  - DKImagePickerController/Core (4.3.2):
-    - DKImagePickerController/ImageDataManager
-    - DKImagePickerController/Resource
-  - DKImagePickerController/ImageDataManager (4.3.2)
-  - DKImagePickerController/PhotoGallery (4.3.2):
-    - DKImagePickerController/Core
-    - DKPhotoGallery
-  - DKImagePickerController/Resource (4.3.2)
-  - DKPhotoGallery (0.0.17):
-    - DKPhotoGallery/Core (= 0.0.17)
-    - DKPhotoGallery/Model (= 0.0.17)
-    - DKPhotoGallery/Preview (= 0.0.17)
-    - DKPhotoGallery/Resource (= 0.0.17)
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Core (0.0.17):
-    - DKPhotoGallery/Model
-    - DKPhotoGallery/Preview
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Model (0.0.17):
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Preview (0.0.17):
-    - DKPhotoGallery/Model
-    - DKPhotoGallery/Resource
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Resource (0.0.17):
-    - SDWebImage
-    - SwiftyGif
-  - file_picker (0.0.1):
-    - DKImagePickerController/PhotoGallery
-    - Flutter
   - Flutter (1.0.0)
-  - SDWebImage (5.12.4):
-    - SDWebImage/Core (= 5.12.4)
-  - SDWebImage/Core (5.12.4)
-  - SwiftyGif (5.4.3)
 
 DEPENDENCIES:
-  - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
 
-SPEC REPOS:
-  trunk:
-    - DKImagePickerController
-    - DKPhotoGallery
-    - SDWebImage
-    - SwiftyGif
-
 EXTERNAL SOURCES:
-  file_picker:
-    :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  DKImagePickerController: b5eb7f7a388e4643264105d648d01f727110fc3d
-  DKPhotoGallery: fdfad5125a9fdda9cc57df834d49df790dbb4179
-  file_picker: 3e6c3790de664ccf9b882732d9db5eaf6b8d4eb1
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  SDWebImage: 631cf572cc93dfdfe54162e556410a61f1141928
-  SwiftyGif: 6c3eafd0ce693cad58bb63d2b2fb9bacb8552780
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
 
-PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
+PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.12.1

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -139,7 +139,6 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				BE44813BDB83FE786F239ED2 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -200,10 +199,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -214,6 +215,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -246,23 +248,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BE44813BDB83FE786F239ED2 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -340,7 +325,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -417,7 +402,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -466,7 +451,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
 import 'dart:developer';
+import 'dart:typed_data';
 
-import 'package:cross_file/cross_file.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_jsonschema_builder/flutter_jsonschema_builder.dart';
 
@@ -110,15 +110,31 @@ class _MyHomePageState extends State<MyHomePage> {
 
         ''';
 
-  Future<List<XFile>?> defaultCustomFileHandler() async {
+  Future<List<SchemaFormFile>?> defaultCustomFileHandler(
+      SchemaProperty property) async {
     await Future.delayed(const Duration(seconds: 3));
 
-    final file1 = XFile(
-        'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg');
-    final file2 = XFile(
-        'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg');
-    final file3 = XFile(
-        'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg');
+    final file1 = SchemaFormFile(
+      name:
+          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+      value:
+          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+      bytes: Uint8List.fromList([]),
+    );
+    final file2 = SchemaFormFile(
+      name:
+          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+      value:
+          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+      bytes: Uint8List.fromList([]),
+    );
+    final file3 = SchemaFormFile(
+      name:
+          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+      value:
+          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+      bytes: Uint8List.fromList([]),
+    );
 
     return [file1, file2, file3];
   }
@@ -140,10 +156,15 @@ class _MyHomePageState extends State<MyHomePage> {
                 },
                 fileHandler: () => {
                   'files': defaultCustomFileHandler,
-                  'file': () async {
+                  'file': (property) async {
                     return [
-                      XFile(
-                          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg')
+                      SchemaFormFile(
+                        name:
+                            'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+                        value:
+                            'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+                        bytes: Uint8List.fromList([]),
+                      )
                     ];
                   },
                   '*': defaultCustomFileHandler
@@ -196,7 +217,8 @@ class _MyHomePageState extends State<MyHomePage> {
                     icon: const Icon(Icons.plus_one),
                     label: const Text('Add Item'),
                   ),
-                  addFileButtonBuilder: (onPressed, key) {
+                  addFileButtonBuilder: (onPressed, property) {
+                    final key = property.idKey;
                     if (['file', 'file3'].contains(key)) {
                       return OutlinedButton(
                         onPressed: onPressed,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,18 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
-  cross_file:
-    dependency: "direct main"
-    description:
-      name: cross_file
-      sha256: "0b0036e8cccbfbe0555fd83c1d31a6f30b77a96b598b35a5d36dd41f718695e9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.3+4"
+    version: "1.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -102,18 +94,18 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "0.18.1"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -126,10 +118,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -142,18 +134,26 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -216,5 +216,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=2.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -138,14 +138,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  mime:
-    dependency: transitive
-    description:
-      name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.4"
   path:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -36,7 +36,6 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  cross_file: ^0.3.3+4
 
 dev_dependencies:
   flutter_test:

--- a/lib/flutter_jsonschema_builder.dart
+++ b/lib/flutter_jsonschema_builder.dart
@@ -1,4 +1,6 @@
 library flutter_jsonschema_builder;
 
 export 'src/builder/widget_builder.dart';
+export 'src/models/property_schema.dart';
 export 'src/models/json_form_schema_style.dart';
+export 'src/models/schema_form_file.dart';

--- a/lib/src/builder/array_schema_builder.dart
+++ b/lib/src/builder/array_schema_builder.dart
@@ -115,20 +115,24 @@ class _ArraySchemaBuilderState extends State<ArraySchemaBuilder> {
 
   void _addFirstItem() {
     if (widget.schemaArray.itemsBaseSchema is Object) {
+      final initialData = WidgetBuilderInherited.of(context).data;
       final newSchema = Schema.fromJson(
         widget.schemaArray.itemsBaseSchema,
         id: '0',
         parent: widget.schemaArray,
+        initialData: initialData,
       );
 
       widget.schemaArray.items = [newSchema];
     } else {
+      final initialData = WidgetBuilderInherited.of(context).data;
       widget.schemaArray.items =
           (widget.schemaArray.itemsBaseSchema as List<Map<String, dynamic>>)
               .map((e) => Schema.fromJson(
                     e,
                     id: '0',
                     parent: widget.schemaArray,
+                    initialData: initialData,
                   ))
               .toList();
     }

--- a/lib/src/builder/array_schema_builder.dart
+++ b/lib/src/builder/array_schema_builder.dart
@@ -6,12 +6,16 @@ import 'package:flutter_jsonschema_builder/src/fields/shared.dart';
 import 'package:flutter_jsonschema_builder/src/models/models.dart';
 
 class ArraySchemaBuilder extends StatefulWidget {
-  const ArraySchemaBuilder(
-      {Key? key, required this.mainSchema, required this.schemaArray})
-      : super(key: key);
+  const ArraySchemaBuilder({
+    Key? key,
+    required this.mainSchema,
+    required this.schemaArray,
+    this.showDebugElements = true,
+  }) : super(key: key);
+
   final Schema mainSchema;
   final SchemaArray schemaArray;
-
+  final bool showDebugElements;
   @override
   State<ArraySchemaBuilder> createState() => _ArraySchemaBuilderState();
 }
@@ -66,6 +70,7 @@ class _ArraySchemaBuilderState extends State<ArraySchemaBuilder> {
                   FormFromSchemaBuilder(
                     mainSchema: widget.mainSchema,
                     schema: schemaLoop,
+                    showDebugElements: widget.showDebugElements,
                   ),
                   if (widget.schemaArray.items.length > 1) const Divider(),
                   const SizedBox(height: 10),

--- a/lib/src/builder/field_header_widget.dart
+++ b/lib/src/builder/field_header_widget.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_jsonschema_builder/flutter_jsonschema_builder.dart';
+import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logic.dart';
+
+class FieldHeader extends StatelessWidget {
+  const FieldHeader({required this.property, Key? key}) : super(key: key);
+  final SchemaProperty property;
+  @override
+  Widget build(BuildContext context) {
+    final description = property.description;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          '${property.title} ${property.required ? "*" : ""}',
+          style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle,
+        ),
+        if (description != null && description.isNotEmpty) ...[
+          const SizedBox(height: 4),
+          Text(
+            description,
+            style: WidgetBuilderInherited.of(context).uiConfig.fieldDescription,
+          ),
+        ]
+      ],
+    );
+  }
+}

--- a/lib/src/builder/logic/widget_builder_logic.dart
+++ b/lib/src/builder/logic/widget_builder_logic.dart
@@ -11,6 +11,7 @@ class WidgetBuilderInherited extends InheritedWidget {
     required this.mainSchema,
     required Widget child,
     this.fileHandler,
+    this.initialFileValueHandler,
     this.customPickerHandler,
     this.customValidatorHandler,
     this.onChanged,
@@ -22,6 +23,7 @@ class WidgetBuilderInherited extends InheritedWidget {
   final Map<String, dynamic> data;
 
   final FileHandler? fileHandler;
+  final InitialFileValueHandler? initialFileValueHandler;
   final CustomPickerHandler? customPickerHandler;
   final CustomValidatorHandler? customValidatorHandler;
   final ValueChanged<dynamic>? onChanged;

--- a/lib/src/builder/logic/widget_builder_logic.dart
+++ b/lib/src/builder/logic/widget_builder_logic.dart
@@ -44,6 +44,7 @@ class WidgetBuilderInherited extends InheritedWidget {
               color: Theme.of(context).colorScheme.error,
               fontSize: textTheme.bodySmall!.fontSize),
       fieldTitle: uiConfig?.fieldTitle ?? textTheme.bodyMedium,
+      fieldDescription: uiConfig?.fieldDescription ?? textTheme.bodySmall,
       label: uiConfig?.label,
       //builders
       addItemBuilder: uiConfig?.addItemBuilder,

--- a/lib/src/builder/logic/widget_builder_logic.dart
+++ b/lib/src/builder/logic/widget_builder_logic.dart
@@ -13,14 +13,18 @@ class WidgetBuilderInherited extends InheritedWidget {
     this.fileHandler,
     this.customPickerHandler,
     this.customValidatorHandler,
-  }) : super(key: key, child: child);
+    this.onChanged,
+    Map<String, dynamic>? initialData,
+  })  : data = initialData ?? {},
+        super(key: key, child: child);
 
   final Schema mainSchema;
-  final data = {};
+  final Map<String, dynamic> data;
 
   final FileHandler? fileHandler;
   final CustomPickerHandler? customPickerHandler;
   final CustomValidatorHandler? customValidatorHandler;
+  final ValueChanged<dynamic>? onChanged;
   late final JsonFormSchemaUiConfig uiConfig;
 
   void setJsonFormSchemaStyle(
@@ -44,6 +48,9 @@ class WidgetBuilderInherited extends InheritedWidget {
       removeItemBuilder: uiConfig?.removeItemBuilder,
       submitButtonBuilder: uiConfig?.submitButtonBuilder,
       addFileButtonBuilder: uiConfig?.addFileButtonBuilder,
+      imagesBuilder: uiConfig?.imagesBuilder,
+      selectionTitle: uiConfig?.selectionTitle,
+      requiredText: uiConfig?.requiredText,
     );
   }
 
@@ -80,6 +87,7 @@ class WidgetBuilderInherited extends InheritedWidget {
 
     object[_keyNumeric ?? _key] = value;
     stack.removeAt(0);
+    onChanged?.call(data);
   }
 
   /// add a new value into a schema,

--- a/lib/src/builder/logic/widget_builder_logic.dart
+++ b/lib/src/builder/logic/widget_builder_logic.dart
@@ -51,7 +51,7 @@ class WidgetBuilderInherited extends InheritedWidget {
       removeItemBuilder: uiConfig?.removeItemBuilder,
       submitButtonBuilder: uiConfig?.submitButtonBuilder,
       addFileButtonBuilder: uiConfig?.addFileButtonBuilder,
-      imagesBuilder: uiConfig?.imagesBuilder,
+      filesBuilder: uiConfig?.filesBuilder,
       selectionTitle: uiConfig?.selectionTitle,
       requiredText: uiConfig?.requiredText,
     );

--- a/lib/src/builder/logic/widget_builder_logic.dart
+++ b/lib/src/builder/logic/widget_builder_logic.dart
@@ -46,14 +46,14 @@ class WidgetBuilderInherited extends InheritedWidget {
       fieldTitle: uiConfig?.fieldTitle ?? textTheme.bodyMedium,
       fieldDescription: uiConfig?.fieldDescription ?? textTheme.bodySmall,
       label: uiConfig?.label,
+      selectionTitle: uiConfig?.selectionTitle,
+      requiredText: uiConfig?.requiredText,
       //builders
       addItemBuilder: uiConfig?.addItemBuilder,
       removeItemBuilder: uiConfig?.removeItemBuilder,
       submitButtonBuilder: uiConfig?.submitButtonBuilder,
       addFileButtonBuilder: uiConfig?.addFileButtonBuilder,
       filesBuilder: uiConfig?.filesBuilder,
-      selectionTitle: uiConfig?.selectionTitle,
-      requiredText: uiConfig?.requiredText,
     );
   }
 

--- a/lib/src/builder/object_schema_builder.dart
+++ b/lib/src/builder/object_schema_builder.dart
@@ -9,10 +9,12 @@ class ObjectSchemaBuilder extends StatefulWidget {
     Key? key,
     required this.mainSchema,
     required this.schemaObject,
+    this.showDebugElements = true,
   }) : super(key: key);
 
   final Schema mainSchema;
   final SchemaObject schemaObject;
+  final bool showDebugElements;
 
   @override
   State<ObjectSchemaBuilder> createState() => _ObjectSchemaBuilderState();
@@ -50,6 +52,7 @@ class _ObjectSchemaBuilderState extends State<ObjectSchemaBuilder> {
                 .map((e) => FormFromSchemaBuilder(
                     schemaObject: widget.schemaObject,
                     mainSchema: widget.mainSchema,
+                    showDebugElements: widget.showDebugElements,
                     schema: e))
                 .toList(),
         ],

--- a/lib/src/builder/property_schema_builder.dart
+++ b/lib/src/builder/property_schema_builder.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:developer';
 
-import 'package:cross_file/cross_file.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/object_schema_logic.dart';
@@ -309,17 +308,20 @@ class PropertySchemaBuilder extends StatelessWidget {
     }
   }
 
-  Future<List<XFile>?> Function() getCustomFileHanlder(
-      FileHandler customFileHandler, String key) {
+  Future<List<SchemaFormFile>?> Function(SchemaProperty property)
+      getCustomFileHanlder(FileHandler customFileHandler, String key) {
     final handlers = customFileHandler();
     assert(handlers.isNotEmpty, 'CustomFileHandler must not be empty');
 
-    if (handlers.containsKey(key))
-      return handlers[key] as Future<List<XFile>?> Function();
+    if (handlers.containsKey(key)) {
+      return handlers[key] as Future<List<SchemaFormFile>?> Function(
+          SchemaProperty);
+    }
 
     if (handlers.containsKey('*')) {
       assert(handlers['*'] != null, 'Default file handler must not be null');
-      return handlers['*'] as Future<List<XFile>?> Function();
+      return handlers['*'] as Future<List<SchemaFormFile>?> Function(
+          SchemaProperty);
     }
 
     throw Exception('no file handler found');
@@ -327,12 +329,12 @@ class PropertySchemaBuilder extends StatelessWidget {
 
   Future<dynamic> Function(Map<dynamic, dynamic>)? _getCustomPickerHanlder(
       BuildContext context, String key) {
-    final customFileHandler =
+    final customPickerHandler =
         WidgetBuilderInherited.of(context).customPickerHandler;
 
-    if (customFileHandler == null) return null;
+    if (customPickerHandler == null) return null;
 
-    final handlers = customFileHandler();
+    final handlers = customPickerHandler();
 
     if (handlers.containsKey(key)) return handlers[key];
 

--- a/lib/src/builder/property_schema_builder.dart
+++ b/lib/src/builder/property_schema_builder.dart
@@ -137,8 +137,11 @@ class PropertySchemaBuilder extends StatelessWidget {
                 'File handler can not be null when using file inputs');
             _field = FileJFormField(
               property: schemaPropertySorted,
-              fileHandler: getCustomFileHanlder(
+              fileHandler: getCustomFileHandler(
                   WidgetBuilderInherited.of(context).fileHandler!,
+                  schemaProperty.id),
+              initialFileValueHandler: getCustomInitialFileValueHandler(
+                  WidgetBuilderInherited.of(context).initialFileValueHandler,
                   schemaProperty.id),
               onSaved: (val) {
                 log('onSaved: FileJFormField  ${schemaProperty.idKey}  : $val');
@@ -309,7 +312,7 @@ class PropertySchemaBuilder extends StatelessWidget {
   }
 
   Future<List<SchemaFormFile>?> Function(SchemaProperty property)
-      getCustomFileHanlder(FileHandler customFileHandler, String key) {
+      getCustomFileHandler(FileHandler customFileHandler, String key) {
     final handlers = customFileHandler();
     assert(handlers.isNotEmpty, 'CustomFileHandler must not be empty');
 
@@ -325,6 +328,30 @@ class PropertySchemaBuilder extends StatelessWidget {
     }
 
     throw Exception('no file handler found');
+  }
+
+  Future<List<SchemaFormFile>?> Function(dynamic defaultValue)?
+      getCustomInitialFileValueHandler(
+    InitialFileValueHandler? initialFileValueHandler,
+    String key,
+  ) {
+    if (initialFileValueHandler == null) return null;
+    final handlers = initialFileValueHandler();
+    assert(handlers.isNotEmpty, 'InitialFileValueHandlers must not be empty');
+
+    if (handlers.containsKey(key)) {
+      return handlers[key] as Future<List<SchemaFormFile>?> Function(dynamic);
+    }
+
+    if (handlers.containsKey('*')) {
+      assert(
+        handlers['*'] != null,
+        'Default initial file value handler must not be null',
+      );
+      return handlers['*'] as Future<List<SchemaFormFile>?> Function(dynamic);
+    }
+
+    throw Exception('no initial file value handler found');
   }
 
   Future<dynamic> Function(Map<dynamic, dynamic>)? _getCustomPickerHanlder(

--- a/lib/src/builder/property_schema_builder.dart
+++ b/lib/src/builder/property_schema_builder.dart
@@ -19,11 +19,13 @@ class PropertySchemaBuilder extends StatelessWidget {
     Key? key,
     required this.mainSchema,
     required this.schemaProperty,
+    this.showDebugElements = true,
     this.onChangeListen,
   }) : super(key: key);
   final Schema mainSchema;
   final SchemaProperty schemaProperty;
   final ValueChanged<dynamic>? onChangeListen;
+  final bool showDebugElements;
 
   @override
   Widget build(BuildContext context) {
@@ -255,7 +257,7 @@ class PropertySchemaBuilder extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const SizedBox(height: 20),
-        if (!kReleaseMode)
+        if (!kReleaseMode && showDebugElements)
           Text(
             'key: ${schemaProperty.idKey}',
             style: const TextStyle(

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -29,8 +29,9 @@ class JsonForm extends StatefulWidget {
   const JsonForm({
     Key? key,
     required this.jsonSchema,
-    this.uiSchema,
     required this.onFormDataSaved,
+    this.showDebugElements = true,
+    this.uiSchema,
     this.fileHandler,
     this.initialFileValueHandler,
     this.jsonFormSchemaUiConfig,
@@ -59,6 +60,12 @@ class JsonForm extends StatefulWidget {
   final ValueChanged<dynamic>? onChanged;
 
   final Map<String, dynamic>? initialData;
+
+  /// Whether to show debug elements like debug labels for each field and inspect button
+  ///
+  /// defaults to `true`,
+  /// Debug labels only show when the app is built for debugging
+  final bool showDebugElements;
 
   @override
   _JsonFormState createState() => _JsonFormState();
@@ -100,7 +107,7 @@ class _JsonFormState extends State<JsonForm> {
             padding: const EdgeInsets.all(15.0),
             child: Column(
               children: <Widget>[
-                if (!kReleaseMode)
+                if (!kReleaseMode && widget.showDebugElements)
                   TextButton(
                     onPressed: () {
                       inspect(mainSchema);
@@ -111,6 +118,7 @@ class _JsonFormState extends State<JsonForm> {
                 FormFromSchemaBuilder(
                   mainSchema: mainSchema,
                   schema: mainSchema,
+                  showDebugElements: widget.showDebugElements,
                 ),
                 const SizedBox(height: 20),
                 widgetBuilderInherited.uiConfig.submitButtonBuilder == null
@@ -171,10 +179,12 @@ class FormFromSchemaBuilder extends StatelessWidget {
     Key? key,
     required this.mainSchema,
     required this.schema,
+    this.showDebugElements = true,
     this.schemaObject,
   }) : super(key: key);
   final Schema mainSchema;
   final Schema schema;
+  final bool showDebugElements;
   final SchemaObject? schemaObject;
 
   @override
@@ -183,12 +193,14 @@ class FormFromSchemaBuilder extends StatelessWidget {
       return PropertySchemaBuilder(
         mainSchema: mainSchema,
         schemaProperty: schema as SchemaProperty,
+        showDebugElements: showDebugElements,
       );
     }
     if (schema is SchemaArray) {
       return ArraySchemaBuilder(
         mainSchema: mainSchema,
         schemaArray: schema as SchemaArray,
+        showDebugElements: showDebugElements,
       );
     }
 
@@ -196,6 +208,7 @@ class FormFromSchemaBuilder extends StatelessWidget {
       return ObjectSchemaBuilder(
         mainSchema: mainSchema,
         schemaObject: schema as SchemaObject,
+        showDebugElements: showDebugElements,
       );
     }
 

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -13,11 +13,17 @@ import 'package:flutter_jsonschema_builder/src/models/json_form_schema_style.dar
 
 import '../models/models.dart';
 
-typedef FileHandler = Map<String, Future<List<SchemaFormFile>?> Function(SchemaProperty property)?>
+typedef FileHandler = Map<String,
+        Future<List<SchemaFormFile>?> Function(SchemaProperty property)?>
     Function();
-typedef CustomPickerHandler = Map<String, Future<dynamic> Function(Map data)> Function();
+typedef InitialFileValueHandler
+    = Map<String, Future<List<SchemaFormFile>?> Function(dynamic defaultValue)?>
+        Function();
+typedef CustomPickerHandler = Map<String, Future<dynamic> Function(Map data)>
+    Function();
 
-typedef CustomValidatorHandler = Map<String, String? Function(dynamic)?> Function();
+typedef CustomValidatorHandler = Map<String, String? Function(dynamic)?>
+    Function();
 
 class JsonForm extends StatefulWidget {
   const JsonForm({
@@ -26,6 +32,7 @@ class JsonForm extends StatefulWidget {
     this.uiSchema,
     required this.onFormDataSaved,
     this.fileHandler,
+    this.initialFileValueHandler,
     this.jsonFormSchemaUiConfig,
     this.customPickerHandler,
     this.customValidatorHandler,
@@ -38,6 +45,10 @@ class JsonForm extends StatefulWidget {
 
   final String? uiSchema;
   final FileHandler? fileHandler;
+
+  /// This handler is for getting the correct initial value for each file, as file is just represented as string sometimes,
+  /// so we would need this handler to turn value into actual representable file field value
+  final InitialFileValueHandler? initialFileValueHandler;
 
   final JsonFormSchemaUiConfig? jsonFormSchemaUiConfig;
 
@@ -64,7 +75,8 @@ class _JsonFormState extends State<JsonForm> {
   void initState() {
     mainSchema = (Schema.fromJson(json.decode(widget.jsonSchema),
         id: kGenesisIdKey, initialData: widget.initialData) as SchemaObject)
-      ..setUiSchema(widget.uiSchema != null ? json.decode(widget.uiSchema!) : null);
+      ..setUiSchema(
+          widget.uiSchema != null ? json.decode(widget.uiSchema!) : null);
 
     super.initState();
   }
@@ -74,6 +86,7 @@ class _JsonFormState extends State<JsonForm> {
     return WidgetBuilderInherited(
       mainSchema: mainSchema,
       fileHandler: widget.fileHandler,
+      initialFileValueHandler: widget.initialFileValueHandler,
       customPickerHandler: widget.customPickerHandler,
       customValidatorHandler: widget.customValidatorHandler,
       onChanged: widget.onChanged,
@@ -105,8 +118,8 @@ class _JsonFormState extends State<JsonForm> {
                         onPressed: () => onSubmit(widgetBuilderInherited),
                         child: const Text('Submit'),
                       )
-                    : widgetBuilderInherited
-                        .uiConfig.submitButtonBuilder!(() => onSubmit(widgetBuilderInherited)),
+                    : widgetBuilderInherited.uiConfig.submitButtonBuilder!(
+                        () => onSubmit(widgetBuilderInherited)),
               ],
             ),
           ),

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -39,6 +39,7 @@ class JsonForm extends StatefulWidget {
     this.customValidatorHandler,
     this.onChanged,
     this.initialData,
+    this.padding = const EdgeInsets.all(16),
   }) : super(key: key);
 
   final String jsonSchema;
@@ -60,6 +61,8 @@ class JsonForm extends StatefulWidget {
   final ValueChanged<dynamic>? onChanged;
 
   final Map<String, dynamic>? initialData;
+
+  final EdgeInsets padding;
 
   /// Whether to show debug elements like debug labels for each field and inspect button
   ///
@@ -104,7 +107,7 @@ class _JsonFormState extends State<JsonForm> {
         return Form(
           key: _formKey,
           child: Container(
-            padding: const EdgeInsets.all(15.0),
+            padding: widget.padding,
             child: Column(
               children: <Widget>[
                 if (!kReleaseMode && widget.showDebugElements)

--- a/lib/src/fields/checkbox_form_field.dart
+++ b/lib/src/fields/checkbox_form_field.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_jsonschema_builder/src/builder/field_header_widget.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logic.dart';
 import 'package:flutter_jsonschema_builder/src/fields/fields.dart';
 import 'package:flutter_jsonschema_builder/src/fields/shared.dart';
@@ -35,8 +36,7 @@ class _CheckboxJFormFieldState extends State<CheckboxJFormField> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('${widget.property.title} ${widget.property.required ? "*" : ""}',
-            style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle),
+        FieldHeader(property: widget.property),
         FormField<bool>(
           key: Key(widget.property.idKey),
           initialValue: widget.property.defaultValue ?? false,

--- a/lib/src/fields/date_form_field.dart
+++ b/lib/src/fields/date_form_field.dart
@@ -45,12 +45,13 @@ class _DateJFormFieldState extends State<DateJFormField> {
 
   @override
   Widget build(BuildContext context) {
+    final uiConfig = WidgetBuilderInherited.of(context).uiConfig;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           '${widget.property.title} ${widget.property.required ? "*" : ""}',
-          style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle,
+          style: uiConfig.fieldTitle,
         ),
         TextFormField(
           key: Key(widget.property.idKey),
@@ -58,10 +59,9 @@ class _DateJFormFieldState extends State<DateJFormField> {
           keyboardType: TextInputType.phone,
           validator: (value) {
             if (widget.property.required && (value == null || value.isEmpty)) {
-              return 'Required';
+              return uiConfig.requiredText ?? 'Required';
             }
-            if (widget.customValidator != null)
-              return widget.customValidator!(value);
+            if (widget.customValidator != null) return widget.customValidator!(value);
             return null;
           },
           // inputFormatters: [DateTextInputJsonFormatter()],
@@ -71,7 +71,9 @@ class _DateJFormFieldState extends State<DateJFormField> {
               : WidgetBuilderInherited.of(context).uiConfig.label,
 
           onSaved: (value) {
-            if (value != null) widget.onSaved(formatter.parse(value));
+            if (value != null && DateTime.tryParse(value) != null) {
+              widget.onSaved(formatter.parse(value));
+            }
           },
           onChanged: (value) {
             try {
@@ -83,10 +85,9 @@ class _DateJFormFieldState extends State<DateJFormField> {
           },
           decoration: InputDecoration(
             hintText: dateFormatString.toUpperCase(),
-            helperText:
-                widget.property.help != null && widget.property.help!.isNotEmpty
-                    ? widget.property.help
-                    : null,
+            helperText: widget.property.help != null && widget.property.help!.isNotEmpty
+                ? widget.property.help
+                : null,
             suffixIcon: IconButton(
               icon: const Icon(Icons.date_range_outlined),
               onPressed: widget.property.readOnly ? null : _openCalendar,

--- a/lib/src/fields/date_form_field.dart
+++ b/lib/src/fields/date_form_field.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_jsonschema_builder/src/builder/field_header_widget.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logic.dart';
 import 'package:flutter_jsonschema_builder/src/fields/fields.dart';
 import 'package:intl/intl.dart';
@@ -49,10 +50,7 @@ class _DateJFormFieldState extends State<DateJFormField> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          '${widget.property.title} ${widget.property.required ? "*" : ""}',
-          style: uiConfig.fieldTitle,
-        ),
+        FieldHeader(property: widget.property),
         TextFormField(
           key: Key(widget.property.idKey),
           controller: txtDateCtrl,
@@ -61,7 +59,8 @@ class _DateJFormFieldState extends State<DateJFormField> {
             if (widget.property.required && (value == null || value.isEmpty)) {
               return uiConfig.requiredText ?? 'Required';
             }
-            if (widget.customValidator != null) return widget.customValidator!(value);
+            if (widget.customValidator != null)
+              return widget.customValidator!(value);
             return null;
           },
           // inputFormatters: [DateTextInputJsonFormatter()],
@@ -85,9 +84,10 @@ class _DateJFormFieldState extends State<DateJFormField> {
           },
           decoration: InputDecoration(
             hintText: dateFormatString.toUpperCase(),
-            helperText: widget.property.help != null && widget.property.help!.isNotEmpty
-                ? widget.property.help
-                : null,
+            helperText:
+                widget.property.help != null && widget.property.help!.isNotEmpty
+                    ? widget.property.help
+                    : null,
             suffixIcon: IconButton(
               icon: const Icon(Icons.date_range_outlined),
               onPressed: widget.property.readOnly ? null : _openCalendar,

--- a/lib/src/fields/dropdown_form_field.dart
+++ b/lib/src/fields/dropdown_form_field.dart
@@ -58,11 +58,14 @@ class _DropDownJFormFieldState extends State<DropDownJFormField> {
       return true;
     }(), '[enumNames] and [enum]  must be the same size ');
 
+    final uiConfig = WidgetBuilderInherited.of(context).uiConfig;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('${widget.property.title} ${widget.property.required ? "*" : ""}',
-            style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle),
+        Text(
+          '${widget.property.title} ${widget.property.required ? "*" : ""}',
+          style: uiConfig.fieldTitle,
+        ),
         GestureDetector(
           onTap: _onTap,
           child: AbsorbPointer(
@@ -70,11 +73,11 @@ class _DropDownJFormFieldState extends State<DropDownJFormField> {
             child: DropdownButtonFormField<dynamic>(
               key: Key(widget.property.idKey),
               autovalidateMode: AutovalidateMode.onUserInteraction,
-              hint: const Text('Seleccione'),
+              hint: Text(uiConfig.selectionTitle ?? 'Select'),
               isExpanded: false,
               validator: (value) {
                 if (widget.property.required && value == null) {
-                  return 'required';
+                  return uiConfig.requiredText ?? 'Required';
                 }
                 if (widget.customValidator != null)
                   return widget.customValidator!(value);

--- a/lib/src/fields/dropdown_form_field.dart
+++ b/lib/src/fields/dropdown_form_field.dart
@@ -27,6 +27,7 @@ class DropDownJFormField extends PropertyFieldWidget<dynamic> {
 
 class _DropDownJFormFieldState extends State<DropDownJFormField> {
   dynamic value;
+  String? propertieKey;
   @override
   void initState() {
     // fill enum property
@@ -38,12 +39,12 @@ class _DropDownJFormFieldState extends State<DropDownJFormField> {
           break;
         default:
           widget.property.enumm =
-              widget.property.enumNames?.map((e) => e.toString()).toList() ??
-                  [];
+              widget.property.enumNames?.map((e) => e.toString()).toList() ?? [];
       }
     }
 
     value = widget.property.defaultValue;
+    propertieKey = widget.property.id;
     widget.triggetDefaultValue();
     super.initState();
   }
@@ -53,8 +54,7 @@ class _DropDownJFormFieldState extends State<DropDownJFormField> {
     assert(widget.property.enumm != null, 'enum is required');
     assert(() {
       if (widget.property.enumNames != null) {
-        return widget.property.enumNames!.length ==
-            widget.property.enumm!.length;
+        return widget.property.enumNames!.length == widget.property.enumm!.length;
       }
       return true;
     }(), '[enumNames] and [enum]  must be the same size ');
@@ -77,8 +77,7 @@ class _DropDownJFormFieldState extends State<DropDownJFormField> {
                 if (widget.property.required && value == null) {
                   return uiConfig.requiredText ?? 'Required';
                 }
-                if (widget.customValidator != null)
-                  return widget.customValidator!(value);
+                if (widget.customValidator != null) return widget.customValidator!(value);
                 return null;
               },
               items: _buildItems(),
@@ -101,7 +100,8 @@ class _DropDownJFormFieldState extends State<DropDownJFormField> {
   void _onTap() async {
     print('ontap');
     if (widget.customPickerHandler == null) return;
-    final response = await widget.customPickerHandler!(_getItems());
+    final items = _getItems();
+    final response = await widget.customPickerHandler!({...items, 'propertyTitle': propertieKey});
     if (response != null) _onChanged(response);
   }
 

--- a/lib/src/fields/dropdown_form_field.dart
+++ b/lib/src/fields/dropdown_form_field.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_jsonschema_builder/src/builder/field_header_widget.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logic.dart';
 import 'package:flutter_jsonschema_builder/src/fields/fields.dart';
 import '../models/models.dart';
@@ -62,10 +63,7 @@ class _DropDownJFormFieldState extends State<DropDownJFormField> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          '${widget.property.title} ${widget.property.required ? "*" : ""}',
-          style: uiConfig.fieldTitle,
-        ),
+        FieldHeader(property: widget.property),
         GestureDetector(
           onTap: _onTap,
           child: AbsorbPointer(

--- a/lib/src/fields/dropdown_form_field.dart
+++ b/lib/src/fields/dropdown_form_field.dart
@@ -101,7 +101,7 @@ class _DropDownJFormFieldState extends State<DropDownJFormField> {
     print('ontap');
     if (widget.customPickerHandler == null) return;
     final items = _getItems();
-    final response = await widget.customPickerHandler!({...items, 'propertyTitle': propertieKey});
+    final response = await widget.customPickerHandler!({...items, 'propertyKey': propertieKey});
     if (response != null) _onChanged(response);
   }
 

--- a/lib/src/fields/dropdown_oneof_form_field.dart
+++ b/lib/src/fields/dropdown_oneof_form_field.dart
@@ -82,11 +82,14 @@ class _SelectedFormFieldState extends State<DropdownOneOfJFormField> {
   Widget build(BuildContext context) {
     assert(widget.property.oneOf != null, 'oneOf is required');
 
+    final uiConfig = WidgetBuilderInherited.of(context).uiConfig;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('${widget.property.title} ${widget.property.required ? "*" : ""}',
-            style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle),
+        Text(
+          '${widget.property.title} ${widget.property.required ? "*" : ""}',
+          style: uiConfig.fieldTitle,
+        ),
         GestureDetector(
           onTap: _onTap,
           child: AbsorbPointer(
@@ -95,11 +98,11 @@ class _SelectedFormFieldState extends State<DropdownOneOfJFormField> {
               key: Key(widget.property.idKey),
               value: valueSelected,
               autovalidateMode: AutovalidateMode.onUserInteraction,
-              hint: const Text('Seleccione'),
+              hint: Text(uiConfig.selectionTitle ?? 'Select'),
               isExpanded: false,
               validator: (value) {
                 if (widget.property.required && value == null) {
-                  return 'required';
+                  return uiConfig.requiredText ?? 'Required';
                 }
                 if (widget.customValidator != null)
                   return widget.customValidator!(value);

--- a/lib/src/fields/dropdown_oneof_form_field.dart
+++ b/lib/src/fields/dropdown_oneof_form_field.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_jsonschema_builder/src/builder/field_header_widget.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logic.dart';
 import 'package:flutter_jsonschema_builder/src/fields/fields.dart';
 import 'package:flutter_jsonschema_builder/src/models/one_of_model.dart';
@@ -86,10 +87,7 @@ class _SelectedFormFieldState extends State<DropdownOneOfJFormField> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          '${widget.property.title} ${widget.property.required ? "*" : ""}',
-          style: uiConfig.fieldTitle,
-        ),
+        FieldHeader(property: widget.property),
         GestureDetector(
           onTap: _onTap,
           child: AbsorbPointer(

--- a/lib/src/fields/file_form_field.dart
+++ b/lib/src/fields/file_form_field.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter_jsonschema_builder/src/builder/field_header_widget.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logic.dart';
 import 'package:flutter_jsonschema_builder/src/fields/fields.dart';
 import 'package:mime/mime.dart';
@@ -80,10 +81,7 @@ class _FileJFormFieldState extends State<FileJFormField> {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              '${widget.property.title} ${widget.property.required ? "*" : ""}',
-              style: widgetBuilderInherited.uiConfig.fieldTitle,
-            ),
+            FieldHeader(property: widget.property),
             const SizedBox(height: 10),
             if (shouldBuildImages)
               widgetBuilderInherited.uiConfig.imagesBuilder!(images!),

--- a/lib/src/fields/number_form_field.dart
+++ b/lib/src/fields/number_form_field.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_jsonschema_builder/src/builder/field_header_widget.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logic.dart';
 import 'package:flutter_jsonschema_builder/src/fields/fields.dart';
 import '../models/models.dart';
@@ -46,10 +47,7 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          '${widget.property.title} ${widget.property.required ? "*" : ""}',
-          style: uiConfig.fieldTitle,
-        ),
+        FieldHeader(property: widget.property),
         TextFormField(
           key: Key(widget.property.idKey),
           keyboardType: TextInputType.number,
@@ -96,7 +94,4 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
       ],
     );
   }
-
-  String get decorationLabelText =>
-      '${widget.property.title} ${widget.property.required ? "*" : ""} ${widget.property.description ?? ""}';
 }

--- a/lib/src/fields/number_form_field.dart
+++ b/lib/src/fields/number_form_field.dart
@@ -42,11 +42,14 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
 
   @override
   Widget build(BuildContext context) {
+    final uiConfig = WidgetBuilderInherited.of(context).uiConfig;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('${widget.property.title} ${widget.property.required ? "*" : ""}',
-            style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle),
+        Text(
+          '${widget.property.title} ${widget.property.required ? "*" : ""}',
+          style: uiConfig.fieldTitle,
+        ),
         TextFormField(
           key: Key(widget.property.idKey),
           keyboardType: TextInputType.number,
@@ -69,7 +72,7 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
               : WidgetBuilderInherited.of(context).uiConfig.label,
           validator: (String? value) {
             if (widget.property.required && value != null && value.isEmpty) {
-              return 'Required';
+              return uiConfig.requiredText ?? 'Required';
             }
             if (widget.property.minLength != null &&
                 value != null &&

--- a/lib/src/fields/radio_button_form_field.dart
+++ b/lib/src/fields/radio_button_form_field.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_jsonschema_builder/src/builder/field_header_widget.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logic.dart';
 import 'package:flutter_jsonschema_builder/src/fields/fields.dart';
 import 'package:flutter_jsonschema_builder/src/fields/shared.dart';
@@ -88,9 +89,7 @@ class _RadioButtonJFormFieldState extends State<RadioButtonJFormField> {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-                '${widget.property.title} ${widget.property.required ? "*" : ""}',
-                style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle),
+            FieldHeader(property: widget.property),
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: List<Widget>.generate(

--- a/lib/src/fields/text_form_field.dart
+++ b/lib/src/fields/text_form_field.dart
@@ -45,11 +45,12 @@ class _TextJFormFieldState extends State<TextJFormField> {
 
   @override
   Widget build(BuildContext context) {
+    final uiConfig = WidgetBuilderInherited.of(context).uiConfig;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text('${widget.property.title} ${widget.property.required ? "*" : ""}',
-            style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle),
+            style: uiConfig.fieldTitle),
         AbsorbPointer(
           absorbing: widget.property.disabled ?? false,
           child: TextFormField(
@@ -75,7 +76,11 @@ class _TextJFormFieldState extends State<TextJFormField> {
               if (widget.property.required && value != null) {
                 final validated = inputValidationJsonSchema(
                     newValue: value, property: widget.property);
-                if (validated != null) return validated;
+                if (validated == 'Required') {
+                  return uiConfig.requiredText ?? validated;
+                } else {
+                  return validated;
+                }
               }
 
               if (widget.customValidator != null)

--- a/lib/src/fields/text_form_field.dart
+++ b/lib/src/fields/text_form_field.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_jsonschema_builder/src/builder/field_header_widget.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logic.dart';
 import 'package:flutter_jsonschema_builder/src/fields/fields.dart';
 import 'package:flutter_jsonschema_builder/src/utils/input_validation_json_schema.dart';
@@ -49,8 +50,7 @@ class _TextJFormFieldState extends State<TextJFormField> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('${widget.property.title} ${widget.property.required ? "*" : ""}',
-            style: uiConfig.fieldTitle),
+        FieldHeader(property: widget.property),
         AbsorbPointer(
           absorbing: widget.property.disabled ?? false,
           child: TextFormField(

--- a/lib/src/models/json_form_schema_style.dart
+++ b/lib/src/models/json_form_schema_style.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_jsonschema_builder/flutter_jsonschema_builder.dart';
 
@@ -17,7 +15,7 @@ class JsonFormSchemaUiConfig {
     this.removeItemBuilder,
     this.submitButtonBuilder,
     this.addFileButtonBuilder,
-    this.imagesBuilder,
+    this.filesBuilder,
     this.selectionTitle,
     this.requiredText,
   });
@@ -51,9 +49,14 @@ class JsonFormSchemaUiConfig {
   Widget? Function(VoidCallback? onPressed, SchemaProperty property)?
       addFileButtonBuilder;
 
-  /// render a custom image preview, it takes a list of Uint8List (image bytes) as a parameter
+  /// render a custom files preview
+  ///
   /// this widget is typically shown above the [addFileButtonBuilder] or default button in file field
   ///
-  /// if it returns null or it is null, images won't be rendered
-  Widget Function(List<Uint8List> images)? imagesBuilder;
+  /// The builder decides what to build based on the [files] provided,
+  /// and [onRemove] callback is provided so you can handle files removal from cusotm widgets
+  ///
+  /// if it returns `null`, default files names widget will be displayed
+  Widget Function(List<SchemaFormFile>? files,
+      {required ValueChanged<String> onRemove})? filesBuilder;
 }

--- a/lib/src/models/json_form_schema_style.dart
+++ b/lib/src/models/json_form_schema_style.dart
@@ -6,6 +6,7 @@ import 'package:flutter_jsonschema_builder/flutter_jsonschema_builder.dart';
 class JsonFormSchemaUiConfig {
   JsonFormSchemaUiConfig({
     this.fieldTitle,
+    this.fieldDescription,
     this.error,
     this.title,
     this.titleAlign,
@@ -22,6 +23,7 @@ class JsonFormSchemaUiConfig {
   });
 
   TextStyle? fieldTitle;
+  TextStyle? fieldDescription;
   TextStyle? error;
   TextStyle? title;
   TextAlign? titleAlign;

--- a/lib/src/models/json_form_schema_style.dart
+++ b/lib/src/models/json_form_schema_style.dart
@@ -1,4 +1,7 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_jsonschema_builder/flutter_jsonschema_builder.dart';
 
 class JsonFormSchemaUiConfig {
   JsonFormSchemaUiConfig({
@@ -13,6 +16,9 @@ class JsonFormSchemaUiConfig {
     this.removeItemBuilder,
     this.submitButtonBuilder,
     this.addFileButtonBuilder,
+    this.imagesBuilder,
+    this.selectionTitle,
+    this.requiredText,
   });
 
   TextStyle? fieldTitle;
@@ -23,8 +29,16 @@ class JsonFormSchemaUiConfig {
   TextStyle? description;
   TextStyle? label;
 
-  Widget Function(VoidCallback onPressed,String key)? addItemBuilder;
-  Widget Function(VoidCallback onPressed,String key)? removeItemBuilder;
+  /// title of the selection widget
+  /// if it is null, it will default to "Select"
+  String? selectionTitle;
+
+  /// text of the required fields
+  /// if it is null, it will default to "Required"
+  String? requiredText;
+
+  Widget Function(VoidCallback onPressed, String key)? addItemBuilder;
+  Widget Function(VoidCallback onPressed, String key)? removeItemBuilder;
 
   /// render a custom submit button
   /// @param [VoidCallback] submit function
@@ -32,6 +46,12 @@ class JsonFormSchemaUiConfig {
 
   /// render a custom button
   /// if it returns null or it is null, it will build default buttom
-  Widget? Function(VoidCallback? onPressed, String key)? addFileButtonBuilder;
+  Widget? Function(VoidCallback? onPressed, SchemaProperty property)?
+      addFileButtonBuilder;
 
+  /// render a custom image preview, it takes a list of Uint8List (image bytes) as a parameter
+  /// this widget is typically shown above the [addFileButtonBuilder] or default button in file field
+  ///
+  /// if it returns null or it is null, images won't be rendered
+  Widget Function(List<Uint8List> images)? imagesBuilder;
 }

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -2,6 +2,7 @@ export 'schema.dart';
 export 'array_schema.dart';
 export 'object_schema.dart';
 export 'property_schema.dart';
+export 'schema_form_file.dart';
 
 const String kNoTitle = 'no-title';
 const String kGenesisIdKey = 'genesis-key';

--- a/lib/src/models/object_schema.dart
+++ b/lib/src/models/object_schema.dart
@@ -18,6 +18,7 @@ class SchemaObject extends Schema {
     String id,
     Map<String, dynamic> json, {
     Schema? parent,
+    Map<String, dynamic>? initialData,
   }) {
     final schema = SchemaObject(
       id: id,
@@ -33,10 +34,10 @@ class SchemaObject extends Schema {
     schema.dependentsAddedBy.addAll(parent?.dependentsAddedBy ?? []);
 
     if (json['properties'] != null) {
-      schema.setProperties(json['properties'], schema);
+      schema.setProperties(json['properties'], schema, initialData);
     }
     if (json['oneOf'] != null) {
-      schema.setOneOf(json['oneOf'], schema);
+      schema.setOneOf(json['oneOf'], schema, initialData);
     }
 
     return schema;
@@ -137,6 +138,7 @@ class SchemaObject extends Schema {
   void setProperties(
     dynamic properties,
     SchemaObject schema,
+    Map<String, dynamic>? initialData,
   ) {
     if (properties == null) return;
     var props = <Schema>[];
@@ -149,6 +151,7 @@ class SchemaObject extends Schema {
         _property,
         id: key,
         parent: schema,
+        initialData: initialData,
       );
 
       if (property is SchemaProperty) {
@@ -165,13 +168,21 @@ class SchemaObject extends Schema {
     this.properties = props;
   }
 
-  void setOneOf(List<dynamic>? oneOf, SchemaObject schema) {
+  void setOneOf(
+    List<dynamic>? oneOf,
+    SchemaObject schema,
+    Map<String, dynamic>? initialData,
+  ) {
     if (oneOf == null) return;
     oneOf.map((e) => Map<String, dynamic>.from(e));
     var oneOfs = <Schema>[];
     for (var element in oneOf) {
       print(element);
-      oneOfs.add(Schema.fromJson(element, parent: schema));
+      oneOfs.add(Schema.fromJson(
+        element,
+        parent: schema,
+        initialData: initialData,
+      ));
     }
 
     this.oneOf = oneOfs;

--- a/lib/src/models/property_schema.dart
+++ b/lib/src/models/property_schema.dart
@@ -58,13 +58,14 @@ class SchemaProperty extends Schema {
     String id,
     Map<String, dynamic> json, {
     Schema? parent,
+    Map<String, dynamic>? initialData,
   }) {
     final property = SchemaProperty(
       id: id,
       title: json['title'],
       type: schemaTypeFromString(json['type']),
       format: propertyFormatFromString(json['format']),
-      defaultValue: safeDefaultValue(json),
+      defaultValue: initialData?[id] ?? safeDefaultValue(json),
       description: json['description'],
       enumm: json['enum'],
       enumNames: json['enumNames'],
@@ -145,6 +146,9 @@ class SchemaProperty extends Schema {
   dynamic dependents;
   bool readOnly;
   bool isMultipleFile = false;
+  bool filePreview = false;
+  String? fileType;
+  List<String>? acceptedFiles;
 
   /// indica si sus dependentes han sido activados por XDependencies
   bool isDependentsActive = false;
@@ -199,6 +203,16 @@ class SchemaProperty extends Schema {
           break;
         case "ui:widget":
           widget = data as String;
+          break;
+        case "ui:options":
+          filePreview = data["filePreview"] ?? false;
+          fileType = data["fileType"];
+          acceptedFiles = data["accept"] != null
+              ? (data["accept"] as String)
+                  .split(',')
+                  .map((e) => e.trim())
+                  .toList()
+              : null;
           break;
         default:
           break;

--- a/lib/src/models/property_schema.dart
+++ b/lib/src/models/property_schema.dart
@@ -146,7 +146,6 @@ class SchemaProperty extends Schema {
   dynamic dependents;
   bool readOnly;
   bool isMultipleFile = false;
-  bool filePreview = false;
   String? fileType;
   List<String>? acceptedFiles;
 
@@ -205,7 +204,6 @@ class SchemaProperty extends Schema {
           widget = data as String;
           break;
         case "ui:options":
-          filePreview = data["filePreview"] ?? false;
           fileType = data["fileType"];
           acceptedFiles = data["accept"] != null
               ? (data["accept"] as String)

--- a/lib/src/models/schema.dart
+++ b/lib/src/models/schema.dart
@@ -22,6 +22,7 @@ class Schema {
     Map<String, dynamic> json, {
     String id = kNoIdKey,
     Schema? parent,
+    Map<String, dynamic>? initialData,
   }) {
     Schema schema;
 
@@ -33,10 +34,16 @@ class Schema {
     }
 
     json['type'] ??= 'object';
+    print('in Schema initialData: $initialData');
 
     switch (schemaTypeFromString(json['type'])) {
       case SchemaType.object:
-        schema = SchemaObject.fromJson(id, json, parent: parent);
+        schema = SchemaObject.fromJson(
+          id,
+          json,
+          parent: parent,
+          initialData: initialData,
+        );
         break;
 
       case SchemaType.array:
@@ -47,9 +54,13 @@ class Schema {
           schema = schema.toSchemaPropertyMultipleFiles();
 
         break;
-
       default:
-        schema = SchemaProperty.fromJson(id, json, parent: parent);
+        schema = SchemaProperty.fromJson(
+          id,
+          json,
+          parent: parent,
+          initialData: initialData,
+        );
         break;
     }
 

--- a/lib/src/models/schema_form_file.dart
+++ b/lib/src/models/schema_form_file.dart
@@ -1,0 +1,33 @@
+import 'dart:typed_data';
+
+/// Representation of a file in the schema form
+///
+/// It holds the title that will be displayed in the form
+class SchemaFormFile {
+  SchemaFormFile({
+    required this.name,
+    required this.value,
+    required this.bytes,
+  });
+
+  /// The name of the file, used for comsetic reasons
+  String name;
+
+  /// The value of the file, used for the form
+  String value;
+
+  /// The bytes of the file, used for cosmetic reasons when displaying previews
+  Uint8List bytes;
+
+  SchemaFormFile copyWith({
+    String? name,
+    String? value,
+    Uint8List? bytes,
+  }) {
+    return SchemaFormFile(
+      name: name ?? this.name,
+      value: value ?? this.value,
+      bytes: bytes ?? this.bytes,
+    );
+  }
+}

--- a/lib/src/utils/input_validation_json_schema.dart
+++ b/lib/src/utils/input_validation_json_schema.dart
@@ -11,10 +11,11 @@ String? inputValidationJsonSchema(
       property.minLength != null) {
     return 'should NOT be shorter than ${property.minLength} characters';
   }
-  
+
   if ((property.format == PropertyFormat.uri)) {
     if (!(isURL(newValue))) {
       return 'you should enter a uri';
     }
   }
+  return null;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -123,14 +123,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  mime:
-    dependency: "direct main"
-    description:
-      name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.4"
   path:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,18 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
-  cross_file:
-    dependency: "direct main"
-    description:
-      name: cross_file
-      sha256: "0b0036e8cccbfbe0555fd83c1d31a6f30b77a96b598b35a5d36dd41f718695e9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.3+4"
+    version: "1.17.1"
   extended_masked_text:
     dependency: "direct main"
     description:
@@ -87,18 +79,18 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "0.18.1"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -111,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -127,18 +119,26 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
+  mime:
+    dependency: "direct main"
+    description:
+      name: mime
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -201,5 +201,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,9 +11,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.17.0
+  intl: ^0.18.0
   extended_masked_text: ^2.3.1
-  cross_file: ^0.3.3+4
+  mime: ^1.0.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
 
   intl: ^0.18.0
   extended_masked_text: ^2.3.1
-  mime: ^1.0.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Added a new Key-Value pair `{...items, 'propertyTitle': propertieKey}`: -> inserted all key-value pairs from items to a new Map with the key-value pair propertyKey : idOfProperty

propertyKey can now be used inside the `customPickerHandler` to access the title of each property.

Access like that:
`reportForm.formSchema['properties'][data['propertyKey']]['title'].toString()`